### PR TITLE
Add a testing workflow with github actions

### DIFF
--- a/.github/workflows/perl-tests.yaml
+++ b/.github/workflows/perl-tests.yaml
@@ -1,0 +1,27 @@
+name: Perl Tests
+
+on: 
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        perl: [ '5.36', '5.34', '5.20' ]
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - run: perl -V
+      - run: cpanm --installdeps .
+      - run: prove -lv t


### PR DESCRIPTION
Adds a basic workflow that should install a matrix of perl versions and
run the test suite.

Uses the setup-perl-environment action to handle the perl install.  No
careful selection of this dependency, it was just towards the top of the
google search.  https://github.com/marketplace/actions/setup-perl-environment