### PR TITLE
[WIP] Add failing test to demonstrate unicode mishandling

### DIFF
--- a/t/lib/UnicodeHeading.pm
+++ b/t/lib/UnicodeHeading.pm
@@ -1,0 +1,15 @@
+package UnicodeHeading;
+# Unicode subroutine names and pod
+
+=head2 $self->get_hat 🎩
+
+something somthing
+
+=cut
+
+sub get_hat {}
+
+
+
+1;
+

--- a/t/unicode_heading.t
+++ b/t/unicode_heading.t
@@ -1,0 +1,12 @@
+#!/usr/bin/perl -w
+use strict;
+use Test::More tests => 3;
+use lib 't/lib';
+
+BEGIN {
+    use_ok( 'Pod::Coverage' );
+}
+
+my $obj = new Pod::Coverage package => 'UnicodeHeading';
+isa_ok( $obj, 'Pod::Coverage' );
+is($obj->coverage, 1, "Wasn't confused by Unicode in the header");


### PR DESCRIPTION
As mentioned in https://github.com/richardc/perl-pod-coverage/issues/2
Pod::Parser doesn't handle encodings, which may cause some form of
failure.

Here in order to understand this, and in the attempt to add a failing
test that can be fixed with the correct behaviour, we add a simple
test fixture UnicodeHeading that refers to U+1F3A9, the Top Hat in a pod
heading.

At present it doesn't fail, so more work needed.